### PR TITLE
[fix] Removing duplicate serviceAccountName

### DIFF
--- a/sidecar-injector/CHANGELOG.md
+++ b/sidecar-injector/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.16.7] - 2024-03-26
+
+### Fixed
+
+- Removed duplicate serviceAccountName in pods
+
 ## [0.16.6] - 2024-03-25
 
 ### Added

--- a/sidecar-injector/Chart.yaml
+++ b/sidecar-injector/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart to automatically install impart proxy inspector
 
 type: application
 
-version: 0.16.6
+version: 0.16.7
 appVersion: "0.16.4"
 
 keywords:

--- a/sidecar-injector/templates/controlnode.yaml
+++ b/sidecar-injector/templates/controlnode.yaml
@@ -74,7 +74,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "sidecar-injector.serviceAccountName" . }}
       volumes:
       {{- if .Values.controlnode.additionalVolumes }}
         {{- toYaml .Values.controlnode.additionalVolumes | nindent 6 }}

--- a/sidecar-injector/templates/deployment.yaml
+++ b/sidecar-injector/templates/deployment.yaml
@@ -157,7 +157,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "sidecar-injector.serviceAccountName" . }}
       volumes:
       - name: certs
         secret:


### PR DESCRIPTION
The `serviceAccountName` config is duplicated, which is causing helm chart to fail when deploying using kustomize.